### PR TITLE
Move "Wrap filenames" option to Look and Feel settings, add persisted preference (closes #116)

### DIFF
--- a/app/src/main/java/ca/pkay/rcloneexplorer/Fragments/FileExplorerFragment.java
+++ b/app/src/main/java/ca/pkay/rcloneexplorer/Fragments/FileExplorerFragment.java
@@ -585,7 +585,6 @@ public class FileExplorerFragment extends Fragment implements   FileExplorerRecy
         SharedPreferences sharedPreferences = PreferenceManager.getDefaultSharedPreferences(context);
         Boolean isWrapFilenames = sharedPreferences.getBoolean(getString(R.string.pref_key_wrap_filenames), true);
         recyclerViewAdapter.setWrapFileNames(isWrapFilenames);
-        menu.findItem(R.id.action_wrap_filenames).setChecked(isWrapFilenames);
 
         if (isInMoveMode || recyclerViewAdapter.isInSelectMode()) {
             setOptionsMenuVisibility(false);
@@ -636,9 +635,6 @@ public class FileExplorerFragment extends Fragment implements   FileExplorerRecy
                 return true;
             case R.id.action_link:
                 new LinkTask().execute(directoryObject.getCurrentPath());
-                return true;
-            case R.id.action_wrap_filenames:
-                wrapFilenames(item);
                 return true;
             case R.id.action_sync:
                 showSyncDialog(directoryObject.getCurrentPath());
@@ -726,15 +722,6 @@ public class FileExplorerFragment extends Fragment implements   FileExplorerRecy
             fetchDirectoryTask.cancel(true);
         }
         fetchDirectoryTask = new FetchDirectoryContent(true).execute();
-    }
-
-    private void wrapFilenames(MenuItem menuItem) {
-        SharedPreferences sharedPreferences = PreferenceManager.getDefaultSharedPreferences(context);
-        SharedPreferences.Editor editor = sharedPreferences.edit();
-        Boolean isChecked = !menuItem.isChecked();
-        editor.putBoolean(getString(R.string.pref_key_wrap_filenames), isChecked);
-        menuItem.setChecked(isChecked);
-        recyclerViewAdapter.setWrapFileNames(isChecked);
     }
 
     private void startThumbnailService() {

--- a/app/src/main/java/ca/pkay/rcloneexplorer/Fragments/FileExplorerFragment.java
+++ b/app/src/main/java/ca/pkay/rcloneexplorer/Fragments/FileExplorerFragment.java
@@ -582,7 +582,10 @@ public class FileExplorerFragment extends Fragment implements   FileExplorerRecy
             menu.findItem(R.id.action_sync).setVisible(false);
         }
 
-        menu.findItem(R.id.action_wrap_filenames).setChecked(true);
+        SharedPreferences sharedPreferences = PreferenceManager.getDefaultSharedPreferences(context);
+        Boolean isWrapFilenames = sharedPreferences.getBoolean(getString(R.string.pref_key_wrap_filenames), true);
+        recyclerViewAdapter.setWrapFileNames(isWrapFilenames);
+        menu.findItem(R.id.action_wrap_filenames).setChecked(isWrapFilenames);
 
         if (isInMoveMode || recyclerViewAdapter.isInSelectMode()) {
             setOptionsMenuVisibility(false);
@@ -726,13 +729,12 @@ public class FileExplorerFragment extends Fragment implements   FileExplorerRecy
     }
 
     private void wrapFilenames(MenuItem menuItem) {
-        if (menuItem.isChecked()) {
-            menuItem.setChecked(false);
-            recyclerViewAdapter.setWrapFileNames(false);
-        } else {
-            menuItem.setChecked(true);
-            recyclerViewAdapter.setWrapFileNames(true);
-        }
+        SharedPreferences sharedPreferences = PreferenceManager.getDefaultSharedPreferences(context);
+        SharedPreferences.Editor editor = sharedPreferences.edit();
+        Boolean isChecked = !menuItem.isChecked();
+        editor.putBoolean(getString(R.string.pref_key_wrap_filenames), isChecked);
+        menuItem.setChecked(isChecked);
+        recyclerViewAdapter.setWrapFileNames(isChecked);
     }
 
     private void startThumbnailService() {

--- a/app/src/main/java/ca/pkay/rcloneexplorer/Settings/LookAndFeelSettingsFragment.java
+++ b/app/src/main/java/ca/pkay/rcloneexplorer/Settings/LookAndFeelSettingsFragment.java
@@ -27,6 +27,8 @@ public class LookAndFeelSettingsFragment extends Fragment {
     private ImageView accentColorPreview;
     private Switch darkThemeSwitch;
     private View darkThemeElement;
+    private Switch wrapFilenamesSwitch;
+    private View wrapFilenamesElement;
     private boolean isDarkTheme;
 
     public interface OnThemeHasChanged {
@@ -86,13 +88,17 @@ public class LookAndFeelSettingsFragment extends Fragment {
         accentColorPreview = view.findViewById(R.id.accent_color_preview);
         darkThemeSwitch = view.findViewById(R.id.dark_theme_switch);
         darkThemeElement = view.findViewById(R.id.dark_theme);
+        wrapFilenamesSwitch = view.findViewById(R.id.wrap_filenames_switch);
+        wrapFilenamesElement = view.findViewById(R.id.wrap_filenames);
     }
 
     private void setDefaultStates() {
         SharedPreferences sharedPreferences = PreferenceManager.getDefaultSharedPreferences(context);
         boolean isDarkTheme = sharedPreferences.getBoolean(getString(R.string.pref_key_dark_theme), false);
+        boolean isWrapFilenames = sharedPreferences.getBoolean(getString(R.string.pref_key_wrap_filenames), true);
 
         darkThemeSwitch.setChecked(isDarkTheme);
+        wrapFilenamesSwitch.setChecked(isWrapFilenames);
     }
 
     private void setClickListeners() {
@@ -100,6 +106,8 @@ public class LookAndFeelSettingsFragment extends Fragment {
         accentColorElement.setOnClickListener(v -> showAccentColorPicker());
         darkThemeElement.setOnClickListener(v -> darkThemeSwitch.setChecked(!darkThemeSwitch.isChecked()));
         darkThemeSwitch.setOnCheckedChangeListener((buttonView, isChecked) -> onDarkThemeClicked(isChecked));
+        wrapFilenamesElement.setOnClickListener(v -> wrapFilenamesSwitch.setChecked(!wrapFilenamesSwitch.isChecked()));
+        wrapFilenamesSwitch.setOnCheckedChangeListener((buttonView, isChecked) -> onWrapFilenamesClicked(isChecked));
     }
 
     private void showPrimaryColorPicker() {
@@ -156,6 +164,15 @@ public class LookAndFeelSettingsFragment extends Fragment {
         SharedPreferences sharedPreferences = PreferenceManager.getDefaultSharedPreferences(context);
         SharedPreferences.Editor editor = sharedPreferences.edit();
         editor.putBoolean(getString(R.string.pref_key_dark_theme), isChecked);
+        editor.apply();
+
+        listener.onThemeChanged();
+    }
+
+    private void onWrapFilenamesClicked(boolean isChecked) {
+        SharedPreferences sharedPreferences = PreferenceManager.getDefaultSharedPreferences(context);
+        SharedPreferences.Editor editor = sharedPreferences.edit();
+        editor.putBoolean(getString(R.string.pref_key_wrap_filenames), isChecked);
         editor.apply();
 
         listener.onThemeChanged();

--- a/app/src/main/res/layout/look_and_feel_settings_fragment.xml
+++ b/app/src/main/res/layout/look_and_feel_settings_fragment.xml
@@ -122,6 +122,39 @@
             android:layout_width="match_parent"
             android:layout_height="1dp"
             android:background="?attr/dividerColor"/>
+
+        <RelativeLayout
+            android:id="@+id/wrap_filenames"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:paddingStart="16dp"
+            android:paddingEnd="16dp"
+            android:paddingTop="24dp"
+            android:paddingBottom="24dp"
+            android:clickable="true"
+            android:focusable="true"
+            android:background="?selectableItemBackground" >
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_centerVertical="true"
+                android:textColor="?attr/textColorPrimary"
+                android:textStyle="bold"
+                android:text="@string/wrap_filenames"/>
+
+            <Switch
+                android:id="@+id/wrap_filenames_switch"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_alignParentEnd="true" />
+
+        </RelativeLayout>
+
+        <View
+            android:layout_width="match_parent"
+            android:layout_height="1dp"
+            android:background="?attr/dividerColor"/>
     </LinearLayout>
 
 </ScrollView>

--- a/app/src/main/res/menu/file_explorer_folder_menu.xml
+++ b/app/src/main/res/menu/file_explorer_folder_menu.xml
@@ -44,10 +44,4 @@
         android:id="@+id/action_empty_trash"
         android:title="@string/empty_trash"
         app:showAsAction="never" />
-
-    <item
-        android:id="@+id/action_wrap_filenames"
-        android:title="@string/wrap_filenames"
-        android:checkable="true"
-        app:showAsAction="never" />
 </menu>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -148,6 +148,7 @@
     <string name="pref_key_color_primary" translatable="false">pref_key_color_primary</string>
     <string name="pref_key_color_accent" translatable="false">pref_key_color_accent</string>
     <string name="pref_key_dark_theme" translatable="false">pref_key_dark_theme</string>
+    <string name="pref_key_wrap_filenames" translatable="false">pref_key_wrap_filenames</string>
     <string name="pref_key_app_updates" translatable="false">pref_key_app_updates</string>
     <string name="pref_key_app_updates_beta" translatable="false">pref_key_app_updates_beta</string>
     <string name="pref_key_crash_reports" translatable="false">pref_key_crash_reports</string>


### PR DESCRIPTION
I've moved the Wrap Filenames option from the file explorer options menu to Settings > Look and Feel, and set it up as an app preference so the setting is persisted between app launches. It defaults to true for new and existing installations (I assume it'll work for existing installations, my phone wouldn't let me overwrite the play store version with my debug apk.)

The reason I added the preference loading into onCreateOptionsMenu where the former menu item was initialised is, I wasn't sure in what context I could access recyclerViewAdapter to set the wrap filenames flag, and figured that loading the value from shared preferences in the same context as the old menu item was the easiest route. My phone is pretty iffy on connecting with USB debugging and I didn't want to introduce any weird error that I couldn't debug on my own.

Tested on my own phone, seems to work great. Sorry about all the commits, please squash on merge.